### PR TITLE
DAOメソッドの非同期化

### DIFF
--- a/app/src/main/java/com/example/jetpacktodoapp/TaskDao.kt
+++ b/app/src/main/java/com/example/jetpacktodoapp/TaskDao.kt
@@ -1,18 +1,20 @@
 package com.example.jetpacktodoapp
 
 import androidx.room.*
+import kotlinx.coroutines.flow.Flow
+
 
 @Dao
 interface TaskDao {
   @Insert
-  fun insertTask(task: Task)
+  suspend fun insertTask(task: Task)
 
   @Query("SELECT * FROM Task")
-  fun loadAllTasks(): List<Task>
+  fun loadAllTasks(): Flow<List<Task>>
 
   @Update
-  fun updateTask(task: Task)
+  suspend fun updateTask(task: Task)
 
   @Delete
-  fun deleteTask(task: Task)
+  suspend fun deleteTask(task: Task)
 }


### PR DESCRIPTION
## 💡 ポイント

### 非同期化する理由
- UIスレッド（MainThread）でDB操作やHTTP通信といった時間のかかる処理を実行すると、ユーザーがアプリを重いと感じる原因になったり、ANRの原因となるため
- ROOM自体がMainThreadでのクエリの実行を許可していない

### 非同期化の方法

| 名前 |内容 | 実装方法 |
| ---- | ---- | ---- |
| 非同期ワンショットクエリ | 1回だけクエリが実行され、データベースのスナップショットを返す | coroutines |
| オブザーバブルクエリ | テーブルに変更があるたびに、新しいデータを取得しにいくクエリ | Flow|

### TaskDaoのメソッドの非同期化方針

| メソッド名 | 非同期クエリの種類 |
| ---- | ---- |
| insertTask | 非同期ワンショットクエリ |
| loadAllTasks | オブザーバブルクエリ |
| updateTask | 非同期ワンショットクエリ |
| deleteTask | 非同期ワンショットクエリ |


