### PR TITLE
タスク全件取得処理の追加

### DIFF
--- a/app/src/main/java/com/example/jetpacktodoapp/MainActivity.kt
+++ b/app/src/main/java/com/example/jetpacktodoapp/MainActivity.kt
@@ -2,19 +2,16 @@ package com.example.jetpacktodoapp
 
 import android.annotation.SuppressLint
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.jetpacktodoapp.components.EditDialog
 import com.example.jetpacktodoapp.ui.theme.JetpackTodoAppTheme
 import dagger.hilt.android.AndroidEntryPoint
@@ -46,6 +43,7 @@ fun MainContent(viewModel: MainViewModel = hiltViewModel()) {
       Icon(imageVector = Icons.Default.Add, contentDescription = "新規作成")
     }
   }) {
-
+    val tasks by viewModel.tasks.collectAsState(initial = emptyList())
+    Log.d("COUNT", tasks.size.toString())
   }
 }

--- a/app/src/main/java/com/example/jetpacktodoapp/MainViewModel.kt
+++ b/app/src/main/java/com/example/jetpacktodoapp/MainViewModel.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -15,6 +16,8 @@ class MainViewModel @Inject constructor(private val taskDao: TaskDao) : ViewMode
   var title by mutableStateOf("")
   var description by mutableStateOf("")
   var isShowDialog by mutableStateOf(false)
+
+  val tasks = taskDao.loadAllTasks().distinctUntilChanged()
 
   fun createTask() {
     viewModelScope.launch {


### PR DESCRIPTION
## 📘 参考
<!-- [参考サイト](参考URL) -->
[状態と Jetpack Compose](https://developer.android.com/jetpack/compose/state?hl=ja)


## 💡 ポイント
<!-- ポイント -->
- distinctUntilChanged()：データベースで変更があっても中身が変わらない場合はtasksが更新されないようにすることができる

```
val tasks = taskDao.loadAllTasks().distinctUntilChanged()
```

- collectAsState()：ViewModelに入っているFlowを状態として扱う

```
 val tasks by viewModel.tasks.collectAsState(initial = emptyList())
```