### PR TITLE
タスク更新機能

### DIFF
--- a/app/src/main/java/com/example/jetpacktodoapp/MainActivity.kt
+++ b/app/src/main/java/com/example/jetpacktodoapp/MainActivity.kt
@@ -49,7 +49,10 @@ fun MainContent(viewModel: MainViewModel = hiltViewModel()) {
 
     TaskList(
       tasks = tasks,
-      onClickRow = { /* TODO */},
+      onClickRow = {
+        viewModel.setEditingTask(it)
+        viewModel.isShowDialog = true
+      },
       onClickDelete = { viewModel.deleteTask(it) },
     );
   }

--- a/app/src/main/java/com/example/jetpacktodoapp/MainViewModel.kt
+++ b/app/src/main/java/com/example/jetpacktodoapp/MainViewModel.kt
@@ -19,6 +19,16 @@ class MainViewModel @Inject constructor(private val taskDao: TaskDao) : ViewMode
 
   val tasks = taskDao.loadAllTasks().distinctUntilChanged()
 
+  private var editingTask: Task? = null
+  val isEditing: Boolean
+    get() = editingTask != null
+
+  fun setEditingTask(task: Task) {
+    editingTask  = task
+    title = task.title
+    description = task.description
+  }
+
   fun createTask() {
     viewModelScope.launch {
       val newTask = Task(
@@ -33,6 +43,16 @@ class MainViewModel @Inject constructor(private val taskDao: TaskDao) : ViewMode
   fun deleteTask(task: Task) {
     viewModelScope.launch {
       taskDao.deleteTask(task)
+    }
+  }
+
+  fun updateTask() {
+    editingTask?.let { task ->
+      viewModelScope.launch {
+        task.title = title
+        task.description = description
+        taskDao.updateTask(task)
+      }
     }
   }
 }

--- a/app/src/main/java/com/example/jetpacktodoapp/components/EditDialog.kt
+++ b/app/src/main/java/com/example/jetpacktodoapp/components/EditDialog.kt
@@ -16,7 +16,7 @@ import com.example.jetpacktodoapp.MainViewModel
 fun EditDialog(viewModel: MainViewModel = hiltViewModel()) {
   AlertDialog(
     onDismissRequest = { viewModel.isShowDialog = false },
-    title = { Text(text = "タスク新規作成") },
+    title = { Text(text = if (viewModel.isEditing) "タスク更新" else "タスク新規作成") },
     text = {
       Column {
         Text(text = "タイトル")
@@ -47,8 +47,12 @@ fun EditDialog(viewModel: MainViewModel = hiltViewModel()) {
         Button(
           modifier = Modifier.width(120.dp),
           onClick = {
+            if (viewModel.isEditing) {
+              viewModel.updateTask()
+            } else {
+              viewModel.createTask()
+            }
             viewModel.isShowDialog = false
-            viewModel.createTask()
           },
         ) {
           Text(text = "OK")


### PR DESCRIPTION

## 💡 ポイント
<!-- ポイント -->
- let： nullの場合はletの中身が実行されない
```
fun updateTask() {
    editingTask?.let { task ->
      viewModelScope.launch {
        task.title = title
        task.description = description
        taskDao.updateTask(task)
      }
    }
  }
```

- タスクをタップした時に、選択したタスクをeditingTaskに代入（setEditingTask()）
→ editingTaskがnullでなくなる。isEditingがtrueになる
```
private var editingTask: Task? = null
  val isEditing: Boolean
    get() = editingTask != null

  fun setEditingTask(task: Task) {
    editingTask  = task
    title = task.title
    description = task.description
  }
```

## 📸 スクリーンショット
<!-- 見た目の変更がある場合 -->

https://github.com/misaki-kawaguchi/JetpackTodoApp/assets/60394359/e7487517-3ad3-4dc5-b458-322b349f943d

